### PR TITLE
Add new global notif settings type & notif settings logic changes

### DIFF
--- a/src/core/components/Settings/components/NotificationSettings.tsx
+++ b/src/core/components/Settings/components/NotificationSettings.tsx
@@ -6,7 +6,7 @@ import { SwitchSetting } from './SwitchSetting';
 
 import { NotificationSettings as Settings } from '../models';
 
-const NOTIFICATION_ORDER = ['comment', 'reaction', 'post'];
+const NOTIFICATION_ORDER = ['comment', 'mention', 'reaction', 'post'];
 const TypeToTile = {
   email: <FormattedMessage id="settings.emailNotifications.title" />,
   push: <FormattedMessage id="settings.pushNotifications.title" />,
@@ -41,7 +41,7 @@ export function NotificationSettings({
     <Box>
       <H3 pb={spacing}>{TypeToTile[type]}</H3>
       <Stack divider={<Box />} spacing={spacing}>
-        {NOTIFICATION_ORDER.map((key) => (
+        {NOTIFICATION_ORDER.filter(key => settings && Object.keys(settings.global).includes(key)).map((key) => (
           <SwitchSetting
             key={key}
             name={key}
@@ -64,7 +64,7 @@ export function NotificationSettings({
                 {community.communityName}
               </Text>
             }
-            isDisabled={isLoading || isDisabled || !settings?.global.post}
+            isDisabled={isLoading || isDisabled }
             isChecked={community.isEnabled}
             onChange={() => onChangeCommunity(community.communityId, !community.isEnabled)}
           />

--- a/src/core/components/Settings/mocks.ts
+++ b/src/core/components/Settings/mocks.ts
@@ -32,5 +32,6 @@ export const settings: NotificationSettings = {
     comment: false,
     reaction: false,
     post: true,
+    mention: false,
   },
 };

--- a/src/core/components/Settings/models.ts
+++ b/src/core/components/Settings/models.ts
@@ -9,6 +9,7 @@ export type NotificationSettings = {
   global: {
     comment: boolean;
     post: boolean;
-    reaction: boolean;
+    reaction?: boolean;
+    mention?: boolean;
   };
 };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -388,6 +388,8 @@
 
   "settings.notifications.comment.label": "Comment",
   "settings.notifications.comment.helper": "When someone comments on your post or comment",
+  "settings.notifications.mention.label": "Mention",
+  "settings.notifications.mention.helper": "When someone mentions you",
   "settings.notifications.reaction.label": "Reaction",
   "settings.notifications.reaction.helper": "When someone reacts on your post or comment",
   "settings.notifications.post.label": "Post",


### PR DESCRIPTION
## Motivation
The notif settings should match the backend & iOS model

## Changes
-> Add new global notif settings type
-> Default post notif settings logic changes

## Testing Done

- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [X] I have successfully completed the manual testing of my changes and the surrounding code