### PR TITLE
fix: Parsing the new timestamp formats correctly

### DIFF
--- a/src/core/components/NotificationTray/components/NotificationRecordItem.tsx
+++ b/src/core/components/NotificationTray/components/NotificationRecordItem.tsx
@@ -120,7 +120,7 @@ export function NotificationRecordItem({
       }
       subTitle={
         <Text size="xs" color="gray">
-          <Time date={Number(serverTimeUpdated)} className="" />
+          <Time date={Date.parse(serverTimeUpdated)} className="" />
         </Text>
       }
       badge={!read && <Badge size="xs" onClick={handleBadgeClick} />}

--- a/src/core/components/NotificationTray/mocks.ts
+++ b/src/core/components/NotificationTray/mocks.ts
@@ -19,7 +19,7 @@ export const mockNotificationRecordPost = {
   ],
   sourceId: '634678647e482b00d99e9fe3',
   sourceType: 'COMMUNITY',
-  serverTimeUpdated: Date.now() - 20 * 1000,
+  serverTimeUpdated: new Date(Date.now() - 20 * 1000).toISOString(),
 };
 
 export const mockNotificationRecordLike = {
@@ -38,7 +38,7 @@ export const mockNotificationRecordLike = {
   ],
   sourceId: '634678647e482b00d43e9fe3',
   sourceType: 'COMMUNITY',
-  serverTimeUpdated: Date.now() - 58 * 1000,
+  serverTimeUpdated: new Date(Date.now() - 58 * 1000).toISOString(),
 };
 
 export const mockNotificationRecordComment = {
@@ -57,5 +57,5 @@ export const mockNotificationRecordComment = {
   ],
   sourceId: '634678647e482re0d43e9fe3',
   sourceType: 'COMMUNITY',
-  serverTimeUpdated: Date.now() - 300 * 1000,
+  serverTimeUpdated: new Date(Date.now() - 300 * 1000).toISOString(),
 };


### PR DESCRIPTION
## Motivation
Timestamps for the new records are in iso strings, not millis, so need to handle them differently.

## Testing Done

- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [x] I have successfully completed the manual testing of my changes and the surrounding code
