### PR TITLE
fix:Increase max community description length

### DIFF
--- a/src/social/components/CommunityForm/index.js
+++ b/src/social/components/CommunityForm/index.js
@@ -241,11 +241,11 @@ const CommunityForm = ({
               <Label htmlFor="description">
                 <FormattedMessage id="community.about" />
               </Label>
-              <Counter>{description.length}/180</Counter>
+              <Counter>{description.length}/5000</Counter>
             </LabelCounterWrapper>
             <AboutTextarea
               {...register('description', {
-                maxLength: { value: 180, message: 'Description text is too long' },
+                maxLength: { value: 5000, message: 'Description text is too long' },
               })}
               data-qa-anchor={`${dataQaAnchor}-community-description-textarea`}
               placeholder="Enter description"

--- a/src/social/components/community/Card/UICommunityCard.js
+++ b/src/social/components/community/Card/UICommunityCard.js
@@ -56,11 +56,7 @@ const UICommunityCard = ({
 
           {loading && <Skeleton count={2} style={{ fontSize: 8 }} />}
 
-          {!loading && (
-            <Truncate lines={2}>
-              <Description title={description}>{description}</Description>
-            </Truncate>
-          )}
+          {!loading && <Description title={description}>{description}</Description>}
 
           {!loading && showMemberCount && (
             <Count>


### PR DESCRIPTION
## Motivation
Communities support descriptions up to 5000 characters long, but the UI restricts it to 180. Coaches would like to have longer descriptions.

## Changes
* Increase the limit on the edit page
* Remove the 2 line truncate restriction when displaying description

## Testing Done
- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [x] I have successfully completed the manual testing of my changes and the surrounding code
