### PR TITLE
fix:Stop truncating, start new lining in community description

### DIFF
--- a/src/social/components/CommunityInfo/UICommunityInfo.js
+++ b/src/social/components/CommunityInfo/UICommunityInfo.js
@@ -1,9 +1,7 @@
 import { CommunityPostSettings } from '@amityco/js-sdk';
 import React from 'react';
 import PropTypes from 'prop-types';
-import Truncate from 'react-truncate-markup';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { H1 } from '@noom/wax-component-library';
 
 import { toHumanString } from '~/helpers/toHumanString';
 import customizableComponent from '~/core/hocs/customization';
@@ -104,9 +102,7 @@ const UICommunityInfo = ({
         </Header>
 
         {description && (
-          <Truncate lines={3}>
-            <Description data-qa-anchor="community-info-description">{description}</Description>
-          </Truncate>
+          <Description data-qa-anchor="community-info-description">{description}</Description>
         )}
 
         {!isJoined && (

--- a/src/social/components/CommunityInfo/styles.js
+++ b/src/social/components/CommunityInfo/styles.js
@@ -100,6 +100,7 @@ export const Divider = styled.div`
 export const Description = styled.div`
   margin-bottom: 20px;
   word-break: break-all;
+  white-space: pre-line;
 `;
 
 export const JoinButton = styled(PrimaryButton)`

--- a/src/social/components/community/Card/UICommunityCard.js
+++ b/src/social/components/community/Card/UICommunityCard.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Stack, Icon } from '@noom/wax-component-library';
 import { FormattedMessage } from 'react-intl';
-import Truncate from 'react-truncate-markup';
 
 import { toHumanString } from '~/helpers/toHumanString';
 import Skeleton from '~/core/components/Skeleton';

--- a/src/social/components/community/Card/styles.js
+++ b/src/social/components/community/Card/styles.js
@@ -69,4 +69,5 @@ export const Count = styled.div`
 export const Description = styled.div`
   ${({ theme }) => theme.typography.caption}
   min-height: 2.5em;
+  white-space: pre-line;
 `;


### PR DESCRIPTION
## Motivation
![image](https://user-images.githubusercontent.com/10712840/224188466-5a811897-09da-4aa7-b809-00e15c9c272d.png)
There was a second component ALSO used to display the community profile, so the one I tested only fixed one screen.

## Changes
* Remove truncate in the other place it was used.
* Allow for newlines in both display components.

## Testing Done
- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [x] I have successfully completed the manual testing of my changes and the surrounding code
