### PR TITLE
Hide Follow feature UI

### DIFF
--- a/src/social/components/UserInfo/UIUserInfo.js
+++ b/src/social/components/UserInfo/UIUserInfo.js
@@ -131,7 +131,8 @@ const UIUserInfo = ({
               >
                 <PencilIcon /> <FormattedMessage id="user.editProfile" />
               </Button>
-              <>
+              {/* Hiding all "follow" features as they are confusing to users (most don't use the personal feed). */}
+              {/* <>
                 {isPrivateNetwork && isFollowPending && (
                   <Button disabled={!connected} onClick={() => onFollowDecline()}>
                     <PendingIconContainer>
@@ -145,7 +146,7 @@ const UIUserInfo = ({
                     <PlusIcon /> <FormattedMessage id="user.follow" />
                   </PrimaryButton>
                 )}
-              </>
+              </> */}
             </ConditionalRender>
           </ActionButtonContainer>
           <OptionMenu options={allOptions} pullRight={false} />
@@ -158,7 +159,8 @@ const UIUserInfo = ({
             <BanIcon width={14} height={14} css="margin-left: 0.265rem; margin-top: 1px;" />
           )}
         </ProfileNameWrapper>
-        <CountContainer>
+        {/* Hiding all "follow" features as most users find them confusing (individual feeds aren't used often) */}
+        {/* <CountContainer>
           <ClickableCount
             onClick={() => {
               setActiveTab(UserFeedTabs.FOLLOWERS);
@@ -177,7 +179,7 @@ const UIUserInfo = ({
             {toHumanString(followerCount)}
           </ClickableCount>
           <FormattedMessage id="counter.followers" />
-        </CountContainer>
+        </CountContainer> */}
         <Description data-qa-anchor="user-info-description">{description}</Description>
 
         {isMyProfile && pendingUsers.length > 0 && isPrivateNetwork && (


### PR DESCRIPTION
## Motivation
The following feature for users is a bit confusing. It only shows things from another user's personal timeline in your feed, but most users are not posting to their personal timeline. We're hiding it since it's not helpful and confuses some people.

## Changes
Commented out the follow button as well as the following/followers labels.

## Testing Done
- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [ ] I have successfully completed the manual testing of my changes and the surrounding code

## Relevant Links
- [Doc](https://docs.google.com/document/d/1nIOtfzcMgwibksp4x86kb13szl47IDTpY1nFJE1bInM/edit)