### PR TITLE
feat: Enable anonymous communities

### DIFF
--- a/src/social/components/CommunityInfo/UICommunityInfo.js
+++ b/src/social/components/CommunityInfo/UICommunityInfo.js
@@ -43,6 +43,7 @@ const UICommunityInfo = ({
   onClickLeaveCommunity,
   canLeaveCommunity,
   canReviewPosts,
+  isAnonymous,
   name,
   postSetting,
 }) => {
@@ -73,13 +74,17 @@ const UICommunityInfo = ({
                 <FormattedMessage id="community.posts" />
               </div>
             </Count>
-            <Divider />
-            <Count>
-              <div className="countNumber">{toHumanString(membersCount || 0)}</div>
-              <div className="countType">
-                <FormattedMessage id="community.members" />
-              </div>
-            </Count>
+            {!isAnonymous && (
+              <>
+                <Divider />
+                <Count>
+                  <div className="countNumber">{toHumanString(membersCount || 0)}</div>
+                  <div className="countType">
+                    <FormattedMessage id="community.members" />
+                  </div>
+                </Count>
+              </>
+            )}
           </CountsContainer>
 
           {isJoined && (
@@ -148,6 +153,7 @@ UICommunityInfo.propTypes = {
   joinCommunity: PropTypes.func,
   canLeaveCommunity: PropTypes.bool,
   canReviewPosts: PropTypes.bool,
+  isAnonymous: PropTypes.bool,
   name: PropTypes.string,
   postSetting: PropTypes.string,
   onClickLeaveCommunity: PropTypes.func,

--- a/src/social/components/CommunityInfo/index.js
+++ b/src/social/components/CommunityInfo/index.js
@@ -7,6 +7,7 @@ import { useNavigation } from '~/social/providers/NavigationProvider';
 import useCommunityOneMember from '~/social/hooks/useCommunityOneMember';
 import UICommunityInfo from './UICommunityInfo';
 import { leaveCommunityConfirmModal } from './leaveScenarioModals';
+import { ANONYMOUS_METADATA } from '~/social/constants';
 
 function usePendingPostCount(
   isReady,
@@ -52,6 +53,7 @@ const CommunityInfo = ({ communityId, currentUserId }) => {
 
   const canLeaveCommunity = isJoined;
   const categoryNames = communityCategories.map(({ name }) => name);
+  const isAnonymous = community.metadata?.[ANONYMOUS_METADATA] ?? false;
 
   const pendingPostsCount = usePendingPostCount(
     isCurrentMemberReady,
@@ -77,6 +79,7 @@ const CommunityInfo = ({ communityId, currentUserId }) => {
       canEditCommunity={canEditCommunity}
       canLeaveCommunity={canLeaveCommunity}
       canReviewPosts={canReviewCommunityPosts}
+      isAnonymous={isAnonymous}
       name={community.displayName}
       postSetting={community.postSetting}
       onEditCommunity={onEditCommunity}

--- a/src/social/constants.js
+++ b/src/social/constants.js
@@ -23,3 +23,5 @@ export const MAXIMUM_MENTIONEES = 30;
 export const LANGUAGE_METADATA = 'localeLanguage';
 export const BUSINESS_TYPE_METADATA = 'businessType';
 export const PARTNER_METADATA = 'partnerId';
+
+export const ANONYMOUS_METADATA = 'isAnonymous';

--- a/src/social/pages/CommunityFeed/index.js
+++ b/src/social/pages/CommunityFeed/index.js
@@ -18,6 +18,7 @@ import FeedHeaderTabs from '~/social/components/FeedHeaderTabs';
 import { CommunityFeedTabs } from './constants';
 import { getTabs } from './utils';
 import { DeclineBanner, Wrapper } from './styles';
+import { ANONYMOUS_METADATA } from '~/social/constants';
 
 const ADMIN_ONLY_POST_SETTING = 'ONLY_ADMIN_CAN_POST';
 
@@ -46,9 +47,16 @@ const CommunityFeed = ({
         community?.postSetting,
         community?.isJoined,
         canReviewCommunityPosts,
+        community?.metadata?.[ANONYMOUS_METADATA] ?? false,
         pendingPostCount,
       ),
-    [community?.postSetting, community?.isJoined, canReviewCommunityPosts, pendingPostCount],
+    [
+      community?.postSetting,
+      community?.isJoined,
+      canReviewCommunityPosts,
+      community?.metadata?.[ANONYMOUS_METADATA],
+      pendingPostCount,
+    ],
   );
 
   const [activeTab, setActiveTab] = useState(CommunityFeedTabs.TIMELINE);

--- a/src/social/pages/CommunityFeed/utils.js
+++ b/src/social/pages/CommunityFeed/utils.js
@@ -5,12 +5,15 @@ import { FormattedMessage } from 'react-intl';
 import { toHumanString } from '~/helpers/toHumanString';
 import { CommunityFeedTabs } from './constants';
 
-export function getTabs(postSetting, isJoined, canReview, pendingPostCount = 0) {
+export function getTabs(postSetting, isJoined, canReview, isAnonymous, pendingPostCount = 0) {
   const tabs = [
     { value: CommunityFeedTabs.TIMELINE, label: <FormattedMessage id="tabs.timeline" /> },
     { value: CommunityFeedTabs.GALLERY, label: <FormattedMessage id="tabs.gallery" /> },
-    { value: CommunityFeedTabs.MEMBERS, label: <FormattedMessage id="tabs.members" /> },
   ];
+
+  if (!isAnonymous) {
+    tabs.push({ value: CommunityFeedTabs.MEMBERS, label: <FormattedMessage id="tabs.members" /> });
+  }
 
   if (isJoined && postSetting === CommunityPostSettings.ADMIN_REVIEW_POST_REQUIRED) {
     const amount = pendingPostCount;


### PR DESCRIPTION
## Motivation
B2B has a requirement for anonymous communities, which are just communities that have the member list inaccessible.

## Changes
If the community is anonymous, hide the members tab and the member count in the header (matches iOS).

## Testing Done
- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [x] I have successfully completed the manual testing of my changes and the surrounding code

## Relevant Links
- [Tech Doc](https://docs.google.com/document/d/13kyTT8nG5U_LmCg1CUABs7WVYfOr3mPN_m-z4O2p38g/edit#heading=h.wfnaf4z2ajx)

## Screenshots
### Before (Not anonymous)
![image](https://user-images.githubusercontent.com/10712840/232141645-0bc2f8e6-0f00-4974-92c4-8ff3df94dec0.png)

### After (Anonymous)
![image](https://user-images.githubusercontent.com/10712840/232141605-ec34a4b9-ede3-4a89-870c-1d46754dcdd5.png)
