### PR TITLE
Add new metadata fields to profile and edit profile

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -410,5 +410,8 @@
   "userMetadata.userType": "Nutzertyp",
   "userMetadata.hasFinishedInitialProfileSync": "Aufnahme abgeschlossen",
   "userMetadata.isMigratedFromCircles": "Von Circles v1 migriert",
+  "userMetadata.localeLanguage": "Sprache",
+  "userMetadata.businessType": "Business Type",
+  "userMetadata.partnerId": "Partner ID",
   "userMetadata.edit.title": "Nutzermetadaten bearbeiten"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -410,5 +410,8 @@
   "userMetadata.userType": "User type",
   "userMetadata.hasFinishedInitialProfileSync": "Finished onboarding",
   "userMetadata.isMigratedFromCircles": "Migrated from Circles v1",
+  "userMetadata.localeLanguage": "Language",
+  "userMetadata.businessType": "Business Type",
+  "userMetadata.partnerId": "Partner ID",
   "userMetadata.edit.title": "Edit user metadata"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -410,5 +410,8 @@
   "userMetadata.userType": "Tipo de usuario",
   "userMetadata.hasFinishedInitialProfileSync": "Incorporación finalizada",
   "userMetadata.isMigratedFromCircles": "Migrado de Círculos v1",
+  "userMetadata.localeLanguage": "Idioma",
+  "userMetadata.businessType": "Business Type",
+  "userMetadata.partnerId": "Partner ID",
   "userMetadata.edit.title": "Editar metadata de usuario"
 }

--- a/src/social/components/UserInfo/UserMetadata.tsx
+++ b/src/social/components/UserInfo/UserMetadata.tsx
@@ -12,6 +12,8 @@ import {
   Td,
   Icon,
   IconButton,
+  Input,
+  RadioGroup,
   Switch,
   Select,
   FormLabel,
@@ -29,6 +31,9 @@ type User = {
     userType?: string;
     hasFinishedInitialProfileSync?: boolean;
     isMigratedFromCircles?: boolean;
+    localeLanguage?: string[];
+    businessType?: string;
+    partnerId?: number;
   };
   createdAt: string;
 };
@@ -54,7 +59,7 @@ type MetadataEditModalProps = {
 
 const MetadataEditModal = ({ user, onClose, isOpen, metadata, onSave }: MetadataEditModalProps) => {
   const { formatMessage } = useIntl();
-  const { register, handleSubmit } = useForm();
+  const { register, handleSubmit, setValue } = useForm();
 
   const onSubmit = (data: User['metadata']) => {
     onSave(user.userId, data), onClose();
@@ -101,6 +106,40 @@ const MetadataEditModal = ({ user, onClose, isOpen, metadata, onSave }: Metadata
               defaultChecked={metadata?.isMigratedFromCircles}
               {...register('isMigratedFromCircles')}
             />
+          </Box>
+          <Box display="flex" flexDir="row" justifyContent="space-between">
+            <FormLabel>
+              <FormattedMessage id="userMetadata.localeLanguage" />
+            </FormLabel>
+            <RadioGroup
+              value={metadata?.localeLanguage?.[0]}
+              isInline={true}
+              colorScheme="primary"
+              onChange={(val) => setValue('localeLanguage.0', val as string)}
+              options={['en', 'de', 'es'].map((key) => ({
+                label: key,
+                value: key,
+              }))}
+            />
+          </Box>
+          <Box display="flex" flexDir="row" justifyContent="space-between">
+            <FormLabel>
+              <FormattedMessage id="userMetadata.businessType" />
+            </FormLabel>
+            <Select
+              options={['B2C', 'B2B'].map((key) => ({
+                label: key,
+                value: key,
+              }))}
+              defaultValue={metadata?.businessType}
+              {...register('businessType')}
+            />
+          </Box>
+          <Box display="flex" flexDir="row" justifyContent="space-between">
+            <FormLabel>
+              <FormattedMessage id="userMetadata.partnerId" />
+            </FormLabel>
+            <Input value={metadata?.partnerId?.toString()} {...register('partnerId')} />
           </Box>
 
           <ButtonGroup w="100%" justifyContent="center">
@@ -172,12 +211,6 @@ export const UIUserMetadata = ({
             </Tr>
             <Tr>
               <Td>
-                <FormattedMessage id="userMetadata.language" />
-              </Td>
-              <Td>{noomMetadata?.localeInformation?.language ?? '-'}</Td>
-            </Tr>
-            <Tr>
-              <Td>
                 <FormattedMessage id="userMetadata.timezone" />
               </Td>
               <Td>{noomMetadata?.localeInformation?.timezone ?? '-'}</Td>
@@ -211,6 +244,24 @@ export const UIUserMetadata = ({
                   <Icon icon="close" />
                 )}
               </Td>
+            </Tr>
+            <Tr>
+              <Td>
+                <FormattedMessage id="userMetadata.localeLanguage" />
+              </Td>
+              <Td>{user.metadata?.localeLanguage?.join(', ')}</Td>
+            </Tr>
+            <Tr>
+              <Td>
+                <FormattedMessage id="userMetadata.businessType" />
+              </Td>
+              <Td>{user.metadata?.businessType}</Td>
+            </Tr>
+            <Tr>
+              <Td>
+                <FormattedMessage id="userMetadata.partnerId" />
+              </Td>
+              <Td>{user.metadata?.partnerId}</Td>
             </Tr>
           </Tbody>
         </Table>

--- a/src/social/components/UserInfo/sdk.stories.js
+++ b/src/social/components/UserInfo/sdk.stories.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { HashRouter as Router, Switch, Route, useHistory, useRouteMatch } from 'react-router-dom';
+import { HashRouter as Router, Switch, Route, useNavigate, useMatch } from 'react-router-dom';
 
 import useOneUser from '~/mock/useOneUser';
 import ProfileSettings from '~/social/components/ProfileSettings';
@@ -14,11 +14,11 @@ export default {
 const SdkUserInfo = () => {
   const user = useOneUser();
 
-  const history = useHistory();
-  const { params = {} } = useRouteMatch('/profile/:userId') || {};
+  const navigate = useNavigate();
+  const { params = {} } = useMatch('/profile/:userId') || {};
   const { userId } = params;
 
-  const editProfile = (id) => history.push(`/profile/${id}/edit`);
+  const editProfile = (id) => navigate(`/profile/${id}/edit`);
 
   if (!user) {
     return (
@@ -51,8 +51,8 @@ export const SdkUserInfoApp = () => {
 SdkUserInfoApp.storyName = 'My User Info';
 
 export const AnotherUserInfo = () => {
-  const [user, loading] = useOneUser();
-  if (!loading)
+  const user = useOneUser();
+  if (!user)
     return (
       <p>
         <FormattedMessage id="loading" />


### PR DESCRIPTION
## Motivation
With the roll out of B2B and international we've added new user metadata tags to handle segmentation. These are based on program parameters, which coaches don't have, because they don't have programs. So we need a way to change these, and the best way is for us to expose the ability to edit them to the coaches themselves. Additionally, doing it this way allows coaches to handle errors on the user side if they come up (say someone switches to B2B from B2C).

Note: Even though user languages under the hood support multiple languages under the hood, I have implemented this as a radio button regardless. The reason for this is because the order of the languages matters for the sake of creating new communities. The plan to support multiple languages for user facing purposes is a future "if needed" effort.

## Changes
* Update the user profile screen to show the new metadata options and add them to the edit screen.
* Fix some errors in a few of the storybook stories

## Testing Done
- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [x] I have successfully completed the manual testing of my changes and the surrounding code

## Relevant Links
- [Jira Ticket](https://noomhq.atlassian.net/browse/LTRGTR-160)
- [Tech Doc](https://docs.google.com/document/d/13kyTT8nG5U_LmCg1CUABs7WVYfOr3mPN_m-z4O2p38g/edit#heading=h.wfnaf4z2ajx)

## Screenshots
<img width="691" alt="image" src="https://user-images.githubusercontent.com/10712840/233715008-b4389f80-fa4e-4aaa-89d0-5769163e900e.png">
<img width="449" alt="image" src="https://user-images.githubusercontent.com/10712840/233715044-ebf0d5a4-4c52-4061-a715-680048832e7d.png">

