### PR TITLE
Add toggle setting for community anonymity

### DIFF
--- a/src/core/providers/ActionProvider.tsx
+++ b/src/core/providers/ActionProvider.tsx
@@ -9,6 +9,7 @@ export type ActionEvents = {
   onPostImpression: (params: { postId: string }) => void;
   onCommentCreate: (params: { isReply: boolean; isDisabled: boolean }) => void;
   onCommentsToggled: (params: { target: 'post' | 'community'; value: 'on' | 'off' }) => void;
+  onAnonymousToggled: (params: { value: 'on' | 'off' }) => void;
 };
 
 export type ActionContextProps = {

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -104,6 +104,9 @@
   "community.review.declinePendingPosts": "Das Ablehnen eines ausstehenden Beitrags wird ihn dauerhaft aus der Community löschen.",
   "community.permissions.disableComments": "Kommentare deaktivieren",
   "community.permissions.disableComments.prompt": "Kommentare zu allen Beiträgen in dieser Community werden ausgeblendet und das Kommentieren wird deaktiviert",
+  "community.permissions.anonymity": "Anonymität",
+  "community.permissions.anonymous": "Machen Sie die Community anonym",
+  "community.permissions.anonymous.prompt": "Anonyme Communitys hindern Benutzer daran, die Mitgliederliste anzuzeigen.",
 
   "community.pendingPostsBanner.title": "Ausstehende Beiträge",
   "community.pendingPostsBanner.pendingForReview": "Deine Beiträge müssen noch überprüft werden",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -104,6 +104,9 @@
   "community.review.declinePendingPosts": "Decline pending post will permanently delete the selected post from community.",
   "community.permissions.disableComments": "Disable comments",
   "community.permissions.disableComments.prompt": "Comments on all posts in this community will be hidden and commenting will be disabled",
+  "community.permissions.anonymity": "Anonymity",
+  "community.permissions.anonymous": "Make community anonymous",
+  "community.permissions.anonymous.prompt": "Anonymous communities prevent users from viewing the list of members.",
 
   "community.pendingPostsBanner.title": "Pending posts",
   "community.pendingPostsBanner.pendingForReview": "Your posts are pending for review",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -104,6 +104,9 @@
   "community.review.declinePendingPosts": "Rechazar la publicación pendiente eliminará permanentemente la publicación seleccionada de la comunidad.",
   "community.permissions.disableComments": "Deshabilitar comentarios",
   "community.permissions.disableComments.prompt": "Se ocultarán los comentarios en todas las publicaciones de esta comunidad y se deshabilitarán los comentarios",
+  "community.permissions.anonymity": "Anonimato",
+  "community.permissions.anonymous": "Hacer anónimo a la comunidad",
+  "community.permissions.anonymous.prompt": "Las comunidades anónimas impiden que los usuarios vean la lista de miembros.",
 
   "community.pendingPostsBanner.title": "Publicaciones pendientes",
   "community.pendingPostsBanner.pendingForReview": "Tus publicaciones están en espera de revisión",

--- a/src/social/components/CommunityPermissions/CommunityPermissions.js
+++ b/src/social/components/CommunityPermissions/CommunityPermissions.js
@@ -12,29 +12,47 @@ export default ({
   onNeedApprovalOnPostCreationChange,
   areCommentsDisabled,
   onDisableComments,
+  isAnonymous,
+  onToggleAnonymous,
 }) => {
   const { formatMessage } = useIntl();
 
   return (
-    <CommunityPermissionsContainer>
-      <CommunityPermissionsHeader>
-        <FormattedMessage id="community.permissions.postReview" />
-      </CommunityPermissionsHeader>
+    <>
+      <CommunityPermissionsContainer>
+        <CommunityPermissionsHeader>
+          <FormattedMessage id="community.permissions.postReview" />
+        </CommunityPermissionsHeader>
 
-      <CommunityPermissionsBody>
-        <SwitchItem
-          value={needApprovalOnPostCreation}
-          onChange={onNeedApprovalOnPostCreationChange}
-          title={formatMessage({ id: 'community.permissions.approvePosts' })}
-          prompt={formatMessage({ id: 'community.permissions.approvePosts.prompt' })}
-        />
-        <SwitchItem
-          value={areCommentsDisabled}
-          onChange={onDisableComments}
-          title={formatMessage({ id: 'community.permissions.disableComments' })}
-          prompt={formatMessage({ id: 'community.permissions.disableComments.prompt' })}
-        />
-      </CommunityPermissionsBody>
-    </CommunityPermissionsContainer>
+        <CommunityPermissionsBody>
+          <SwitchItem
+            value={needApprovalOnPostCreation}
+            onChange={onNeedApprovalOnPostCreationChange}
+            title={formatMessage({ id: 'community.permissions.approvePosts' })}
+            prompt={formatMessage({ id: 'community.permissions.approvePosts.prompt' })}
+          />
+          <SwitchItem
+            value={areCommentsDisabled}
+            onChange={onDisableComments}
+            title={formatMessage({ id: 'community.permissions.disableComments' })}
+            prompt={formatMessage({ id: 'community.permissions.disableComments.prompt' })}
+          />
+        </CommunityPermissionsBody>
+      </CommunityPermissionsContainer>
+      <CommunityPermissionsContainer>
+        <CommunityPermissionsHeader>
+          <FormattedMessage id="community.permissions.anonymity" />
+        </CommunityPermissionsHeader>
+
+        <CommunityPermissionsBody>
+          <SwitchItem
+            value={isAnonymous}
+            onChange={onToggleAnonymous}
+            title={formatMessage({ id: 'community.permissions.anonymous' })}
+            prompt={formatMessage({ id: 'community.permissions.anonymous.prompt' })}
+          />
+        </CommunityPermissionsBody>
+      </CommunityPermissionsContainer>
+    </>
   );
 };

--- a/src/social/components/CommunityPermissions/index.js
+++ b/src/social/components/CommunityPermissions/index.js
@@ -4,6 +4,7 @@ import withSDK from '~/core/hocs/withSDK';
 import UICommunityPermissions from './CommunityPermissions';
 import { usePermission } from './utils';
 import useCommunity from '~/social/hooks/useCommunity';
+import { ANONYMOUS_METADATA } from '~/social/constants';
 
 function shouldCommentsBeDisabled(communityMetadata) {
   return communityMetadata?.areCommentsHidden && communityMetadata?.isCommentingDisabled;
@@ -14,7 +15,7 @@ const CommunityPermissions = ({ communityId }) => {
     communityId,
     'needApprovalOnPostCreation',
   );
-  const { community, handleCommentingToggle } = useCommunity(communityId);
+  const { community, handleCommentingToggle, handleAnonymousToggle } = useCommunity(communityId);
 
   return (
     <UICommunityPermissions
@@ -22,6 +23,8 @@ const CommunityPermissions = ({ communityId }) => {
       onNeedApprovalOnPostCreationChange={updateNeedApprovalOnPostCreation}
       areCommentsDisabled={shouldCommentsBeDisabled(community?.metadata)}
       onDisableComments={handleCommentingToggle}
+      isAnonymous={community?.metadata?.[ANONYMOUS_METADATA]}
+      onToggleAnonymous={handleAnonymousToggle}
     />
   );
 };

--- a/src/social/hooks/useCommunity.js
+++ b/src/social/hooks/useCommunity.js
@@ -3,6 +3,7 @@ import { CommunityRepository } from '@amityco/js-sdk';
 import useLiveObject from '~/core/hooks/useLiveObject';
 import useFile from '~/core/hooks/useFile';
 import { useActionEvents } from '~/core/providers/ActionProvider';
+import { ANONYMOUS_METADATA } from '~/social/constants';
 
 const useCommunity = (communityId, resolver) => {
   const community = useLiveObject(
@@ -69,6 +70,19 @@ const useCommunity = (communityId, resolver) => {
     });
   };
 
+  const handleAnonymousToggle = () => {
+    updateCommunity({
+      metadata: {
+        ...community.metadata,
+        [ANONYMOUS_METADATA]: !community.metadata[ANONYMOUS_METADATA],
+      },
+    });
+
+    actionEvents.onAnonymousToggled?.({
+      value: community.metadata[ANONYMOUS_METADATA] ? 'on' : 'off',
+    });
+  };
+
   return {
     community,
     file,
@@ -78,6 +92,7 @@ const useCommunity = (communityId, resolver) => {
     updateCommunity,
     closeCommunity,
     handleCommentingToggle,
+    handleAnonymousToggle,
   };
 };
 


### PR DESCRIPTION
## Motivation
I was originally planning on updating this setting manually upon request, maybe with a script, but then I realized I don't want people to ask me for things if I can make it so they can do it themselves.

## Changes
Add a new setting to the permissions screen of communities that allows coaches to make them anonymous.

## Testing Done
- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [x] I have successfully completed the manual testing of my changes and the surrounding code
