### PR TITLE
Fix the broken language selection in user metadata

### DIFF
--- a/src/social/components/UserInfo/UserMetadata.tsx
+++ b/src/social/components/UserInfo/UserMetadata.tsx
@@ -13,7 +13,6 @@ import {
   Icon,
   IconButton,
   Input,
-  RadioGroup,
   Switch,
   Select,
   FormLabel,
@@ -111,15 +110,13 @@ const MetadataEditModal = ({ user, onClose, isOpen, metadata, onSave }: Metadata
             <FormLabel>
               <FormattedMessage id="userMetadata.localeLanguage" />
             </FormLabel>
-            <RadioGroup
-              value={metadata?.localeLanguage?.[0]}
-              isInline={true}
-              colorScheme="primary"
-              onChange={(val) => setValue('localeLanguage.0', val as string)}
+            <Select
               options={['en', 'de', 'es'].map((key) => ({
                 label: key,
                 value: key,
               }))}
+              defaultValue={metadata?.localeLanguage?.[0]}
+              {...register('localeLanguage.0')}
             />
           </Box>
           <Box display="flex" flexDir="row" justifyContent="space-between">


### PR DESCRIPTION
## Motivation
The language selector for users wasn't keeping the value when you'd try to change it.

## Changes
Switched to a Select because I can't figure out how to make it work with a RadioGroup.

## Testing Done
- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [x] I have successfully completed the manual testing of my changes and the surrounding code
