### PR TITLE
Remove Coach label from posts and name labels

### DIFF
--- a/src/social/components/Comment/Comment.styles.js
+++ b/src/social/components/Comment/Comment.styles.js
@@ -78,7 +78,6 @@ const StyledComment = ({
   ].filter(Boolean);
 
   const isEmpty = !markup || markup?.trim().length === 0;
-  const formattedAuthorType = authorType ? formatMessage({ id: `userType.${authorType}` }) : '';
 
   return (
     <>
@@ -106,7 +105,6 @@ const StyledComment = ({
           <CommentHeader>
             <AuthorName isHighlighted={!!authorType} onClick={onClickUser}>
               {authorName}
-              {formattedAuthorType && ` - ${formattedAuthorType}`}
             </AuthorName>
             <Truncate.Atom>
               {isBanned && <BanIcon css="margin-left: 0.265rem; margin-top: 1px;" />}

--- a/src/social/components/post/Header/UIPostHeader.js
+++ b/src/social/components/post/Header/UIPostHeader.js
@@ -37,7 +37,6 @@ const UIPostHeader = ({
   isBanned,
 }) => {
   const { formatMessage } = useIntl();
-  const formattedAuthorType = userType ? formatMessage({ id: `userType.${userType}` }) : '';
 
   const renderPostNames = () => {
     return (
@@ -50,7 +49,6 @@ const UIPostHeader = ({
             isHighlighted={!!userType}
           >
             {postAuthorName}
-            {formattedAuthorType && ` - ${formattedAuthorType}`}
           </Name>
         </TruncateMarkup>
 


### PR DESCRIPTION
## Motivation
Coaching has been asking for this change for a little bit, but they want to remove the - Noom Coach label appended to their names when posting and commenting. The reason is they want to add "Coach" to their actual name so it shows up in their user name everywhere, but don't want the redundancy.

## Changes
Removed the label from the two places it was used.
