### PR TITLE
Additional workflows to assist sting (and coaches in general)

### DIFF
--- a/src/helpers/permissions.js
+++ b/src/helpers/permissions.js
@@ -108,3 +108,11 @@ export function canReportPost({ userId, user, communityUser, post, community }) 
 
   return !isMyPost;
 }
+
+export function canPerformUserLookups({actingUserType, targetUserType}) {
+  return actingUserType === "coach" && targetUserType === "user";
+}
+
+export function canPerformStingActions({actingUserType, targetUserType}) {
+  return actingUserType === "coach" && targetUserType === "user";
+}

--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -429,5 +429,18 @@
   "privateDescription": "Nur vom Moderator eingeladene Mitglieder können der Community beitreten und die Beiträge in ihr ansehen und durchsuchen.",
   "public": "Öffentlich",
   "publicDescription": "Jeder kann dieser Community beitreten und die Beiträge in ihr ansehen und durchsuchen.",
-  "whatsGoingOnPlaceholder": "Was möchtest du schreiben?"
+  "whatsGoingOnPlaceholder": "Was möchtest du schreiben?",
+
+  "post.dashboard": "Go to user's Dashboard",
+  "post.manatee": "Lookup user in Manatee",
+  "post.sting": "STING",
+  "sting.userNotInStingDash": "This user is NOT currently on the STING Dash",
+  "sting.userInStingDash": "This user IS currently on the STING Dash",
+  "sting.notesPlaceholder": "Why is this post STING-related? (Required)",
+  "sting.notesAreRequired": "Notes are required.",
+  "sting.coachNotes": "Coach Notes",
+  "sting.messagePlaceholder": "Enter a message to be sent to the user from the STING Guide after being transferred. (Optional)",
+  "sting.messageToSend": "Message to send to user",
+  "sting.addNewNote": "Add New Note",
+  "sting.transferUser": "Transfer User to STING Dash"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -429,5 +429,18 @@
   "privateDescription": "Only members invited by the moderators can join, view, and search the posts in this page.",
   "public": "Public",
   "publicDescription": "Anyone can join, view and search the posts in this page.",
-  "whatsGoingOnPlaceholder": "What's going on..."
+  "whatsGoingOnPlaceholder": "What's going on...",
+
+  "post.dashboard": "Go to user's Dashboard",
+  "post.manatee": "Lookup user in Manatee",
+  "post.sting": "STING",
+  "sting.userNotInStingDash": "This user is NOT currently on the STING Dash",
+  "sting.userInStingDash": "This user IS currently on the STING Dash",
+  "sting.notesPlaceholder": "Why is this post STING-related? (Required)",
+  "sting.notesAreRequired": "Notes are required.",
+  "sting.coachNotes": "Coach Notes",
+  "sting.messagePlaceholder": "Enter a message to be sent to the user from the STING Guide after being transferred. (Optional)",
+  "sting.messageToSend": "Message to send to user",
+  "sting.addNewNote": "Add New Note",
+  "sting.transferUser": "Transfer User to STING Dash"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -429,5 +429,18 @@
   "privateDescription": "Solo los miembros invitados por los moderadores pueden unirse, ver y buscar las publicaciones en esta comunidad.",
   "public": "Publicar",
   "publicDescription": "Cualquiera puede unirse, ver y buscar las publicaciones en esta comunidad.",
-  "whatsGoingOnPlaceholder": "Qué está pasando..."
+  "whatsGoingOnPlaceholder": "Qué está pasando...",
+
+  "post.dashboard": "Go to user's Dashboard",
+  "post.manatee": "Lookup user in Manatee",
+  "post.sting": "STING",
+  "sting.userNotInStingDash": "This user is NOT currently on the STING Dash",
+  "sting.userInStingDash": "This user IS currently on the STING Dash",
+  "sting.notesPlaceholder": "Why is this post STING-related? (Required)",
+  "sting.notesAreRequired": "Notes are required.",
+  "sting.coachNotes": "Coach Notes",
+  "sting.messagePlaceholder": "Enter a message to be sent to the user from the STING Guide after being transferred. (Optional)",
+  "sting.messageToSend": "Message to send to user",
+  "sting.addNewNote": "Add New Note",
+  "sting.transferUser": "Transfer User to STING Dash"
 }

--- a/src/social/components/Comment/Comment.styles.js
+++ b/src/social/components/Comment/Comment.styles.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import Truncate from 'react-truncate-markup';
 import PropTypes from 'prop-types';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 
 import { POSITION_LEFT } from '~/helpers/getCssPosition';
 import Button, { PrimaryButton } from '~/core/components/Button';
@@ -27,10 +27,16 @@ import {
   CommentEditTextarea,
   ButtonContainer,
   EditedMark,
+  AccessCode,
+  NameBlock,
 } from './styles';
+import { useDisclosure } from '@noom/wax-component-library';
+import { StingModal } from '../Sting/StingModal';
 
 const StyledComment = ({
   commentId,
+  commentPath,
+  authorId,
   authorName,
   authorAvatar,
   authorType,
@@ -39,6 +45,8 @@ const StyledComment = ({
   canLike = true,
   canReply = false,
   canReport = true,
+  canLookup = false,
+  canSting = false,
   createdAt,
   editedAt,
   text,
@@ -50,6 +58,8 @@ const StyledComment = ({
   startEditing,
   cancelEditing,
   handleDelete,
+  handleLookup,
+  handleOpenDash,
   isEditing,
   onChange,
   queryMentionees,
@@ -60,9 +70,10 @@ const StyledComment = ({
   metadata,
   handleCopyPath,
   isOldStyle,
-  isCommentingEnabled,
+  displayAccessCode = false,
 }) => {
-  const { formatMessage } = useIntl();
+
+  const { isOpen: isStingModalOpen, onOpen: onOpenStingModal, onClose: onCloseStingModal } = useDisclosure();
 
   const options = [
     canEdit && { name: isReplyComment ? 'reply.edit' : 'comment.edit', action: startEditing },
@@ -75,6 +86,9 @@ const StyledComment = ({
       name: 'post.copyPath',
       action: handleCopyPath,
     },
+    canLookup && { name: 'post.manatee', action: handleLookup },
+    canLookup && { name: 'post.dashboard', action: handleOpenDash },
+    canSting && { name: 'post.sting', action: onOpenStingModal },
   ].filter(Boolean);
 
   const isEmpty = !markup || markup?.trim().length === 0;
@@ -103,9 +117,12 @@ const StyledComment = ({
           lines={2}
         >
           <CommentHeader>
-            <AuthorName isHighlighted={!!authorType} onClick={onClickUser}>
-              {authorName}
-            </AuthorName>
+            <NameBlock>
+              <AuthorName isHighlighted={!!authorType} onClick={onClickUser}>
+                {authorName} 
+              </AuthorName>
+              {displayAccessCode && <AccessCode>{` (${authorId})`}</AccessCode>}
+            </NameBlock>
             <Truncate.Atom>
               {isBanned && <BanIcon css="margin-left: 0.265rem; margin-top: 1px;" />}
               <CommentDate date={createdAt} />
@@ -168,12 +185,21 @@ const StyledComment = ({
           </InteractionBar>
         )}
       </Content>
+
+      <StingModal
+        userAccessCode={authorId}
+        pathToContent={commentPath}
+        isOpen={isStingModalOpen}
+        onClose={onCloseStingModal}
+      />
     </>
   );
 };
 
 StyledComment.propTypes = {
   commentId: PropTypes.string,
+  commentPath: PropTypes.string,
+  authorId: PropTypes.string,
   authorName: PropTypes.string,
   authorAvatar: PropTypes.string,
   canDelete: PropTypes.bool,
@@ -181,6 +207,8 @@ StyledComment.propTypes = {
   canLike: PropTypes.bool,
   canReply: PropTypes.bool,
   canReport: PropTypes.bool,
+  canLookup: PropTypes.bool,
+  canSting: PropTypes.bool,
   createdAt: PropTypes.instanceOf(Date),
   editedAt: PropTypes.instanceOf(Date),
   text: PropTypes.string,
@@ -190,6 +218,8 @@ StyledComment.propTypes = {
   startEditing: PropTypes.func.isRequired,
   cancelEditing: PropTypes.func.isRequired,
   handleDelete: PropTypes.func.isRequired,
+  handleLookup: PropTypes.func.isRequired,
+  handleOpenDash: PropTypes.func.isRequired,
   mentionees: PropTypes.array,
   metadata: PropTypes.object,
   isEditing: PropTypes.bool,
@@ -201,6 +231,7 @@ StyledComment.propTypes = {
   onChange: PropTypes.func.isRequired,
   handleCopyPath: PropTypes.func,
   authorType: PropTypes.string,
+  displayAccessCode: PropTypes.bool,
 };
 
 export default StyledComment;

--- a/src/social/components/Comment/styles.js
+++ b/src/social/components/Comment/styles.js
@@ -86,6 +86,16 @@ export const AuthorName = styled.div`
   `}
 `;
 
+export const NameBlock = styled.div`
+  display: flex;
+`;
+
+export const AccessCode = styled.div`
+  ${({ theme }) => theme.typography.caption}
+
+  color: #c3c4c3;
+`;
+
 export const CommentDate = styled(Time)`
   display: inline;
 

--- a/src/social/components/Sting/StingModal.tsx
+++ b/src/social/components/Sting/StingModal.tsx
@@ -1,0 +1,132 @@
+import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Container,
+  FormLabel,
+  Loader,
+  Stack,
+  Textarea,
+} from '@noom/wax-component-library';
+import { FormattedMessage, useIntl } from 'react-intl';
+import Modal from '~/core/components/Modal';
+import { useConfig } from '~/social/providers/ConfigProvider';
+import { ErrorMessage } from '../CommunityForm/styles';
+
+type StingModalProps = {
+  userAccessCode: string;
+  pathToContent: string;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export const StingModal = ({ userAccessCode, pathToContent, isOpen, onClose }: StingModalProps) => {
+  const { formatMessage } = useIntl();
+  const {
+    formState: { errors },
+    register,
+    handleSubmit,
+    reset,
+    setError,
+  } = useForm();
+  const { isUserCurrentlyInStingDashCallback, addCoachNoteCallback, transferUserToStingCallback } =
+    useConfig();
+  const [userInStingDash, setUserInStingDash] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (isOpen) {
+      (async () => {
+        const inStingDash = await isUserCurrentlyInStingDashCallback(userAccessCode);
+        setUserInStingDash(inStingDash);
+        setIsLoading(false);
+      })();
+    }
+  }, [userAccessCode, isOpen]);
+
+  useEffect(() => {
+    setIsLoading(true);
+    reset();
+  }, [isOpen]);
+
+  const onSubmit = async (data: { messageToSend: string | undefined; coachNotes: string }) => {
+    let canAttachNote = true;
+    if (!userInStingDash) {
+      canAttachNote = await transferUserToStingCallback(userAccessCode, data.messageToSend);
+    }
+    if (canAttachNote) {
+      const realPath = pathToContent.replace(
+        /.+\/social\//,
+        `${window.location.protocol}//${window.location.hostname}/`,
+      );
+      addCoachNoteCallback(
+        userAccessCode,
+        `${data.coachNotes}\n\nPath to Circles content:\n${realPath}`,
+      );
+    }
+    onClose();
+  };
+
+  const validateAndSubmit = async (data) => {
+    if (!data.coachNotes) {
+      setError('coachNotes', {
+        message: formatMessage({ id: 'sting.notesAreRequired' }),
+      });
+      return;
+    }
+    onSubmit(data);
+  };
+
+  const statusLabelId = userInStingDash ? 'sting.userInStingDash' : 'sting.userNotInStingDash';
+  const buttonLabelId = userInStingDash ? 'sting.addNewNote' : 'sting.transferUser';
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      data-qa-anchor="sting-modal"
+      title={isLoading ? '' : formatMessage({ id: statusLabelId })}
+      onCancel={onClose}
+    >
+      {isLoading ? (
+        <Container centerHorizontal>
+          <Loader size="md" colorScheme="primary" />
+        </Container>
+      ) : (
+        <form onSubmit={handleSubmit(validateAndSubmit)}>
+          <Stack>
+            <Box>
+              <FormLabel>
+                <FormattedMessage id="sting.coachNotes" />
+              </FormLabel>
+              <Textarea
+                placeholder={formatMessage({ id: 'sting.notesPlaceholder' })}
+                {...register('coachNotes')}
+              />
+              <ErrorMessage errors={errors} name="coachNotes" />
+            </Box>
+            {!userInStingDash && (
+              <Box>
+                <FormLabel>
+                  <FormattedMessage id="sting.messageToSend" />
+                </FormLabel>
+                <Textarea
+                  placeholder={formatMessage({ id: 'sting.messagePlaceholder' })}
+                  {...register('messageToSend')}
+                />
+              </Box>
+            )}
+
+            <ButtonGroup w="100%" justifyContent="center">
+              <Button colorScheme="primary" type="submit">
+                <FormattedMessage id={buttonLabelId} />
+              </Button>
+            </ButtonGroup>
+          </Stack>
+        </form>
+      )}
+    </Modal>
+  );
+};

--- a/src/social/components/post/Header/UIPostHeader.js
+++ b/src/social/components/post/Header/UIPostHeader.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import cx from 'classnames';
 import TruncateMarkup from 'react-truncate-markup';
 import Skeleton from '~/core/components/Skeleton';
@@ -10,6 +10,7 @@ import Avatar from '~/core/components/Avatar';
 import BanIcon from '~/icons/Ban';
 import { backgroundImage as UserImage } from '~/icons/User';
 import {
+  AccessCode,
   Name,
   PostInfo,
   ShieldIcon,
@@ -25,6 +26,7 @@ const UIPostHeader = ({
   userType,
   avatarFileUrl,
   postAuthorName,
+  postAuthorId,
   postTargetName,
   timeAgo,
   isModerator,
@@ -36,8 +38,6 @@ const UIPostHeader = ({
   loading,
   isBanned,
 }) => {
-  const { formatMessage } = useIntl();
-
   const renderPostNames = () => {
     return (
       <PostNamesContainer data-qa-anchor="post-header-post-names">
@@ -51,6 +51,12 @@ const UIPostHeader = ({
             {postAuthorName}
           </Name>
         </TruncateMarkup>
+
+        {postAuthorId && 
+          <AccessCode data-qa-anchor="post-header-post-accesscode">
+            {`(${postAuthorId})`}
+          </AccessCode>
+        }
 
         {isBanned && <BanIcon height={14} width={14} />}
       </PostNamesContainer>
@@ -119,6 +125,7 @@ UIPostHeader.propTypes = {
   userType: PropTypes.string,
   avatarFileUrl: PropTypes.string,
   postAuthorName: PropTypes.node,
+  postAuthorId: PropTypes.string,
   postTargetName: PropTypes.string,
   timeAgo: PropTypes.instanceOf(Date),
   isModerator: PropTypes.bool,
@@ -134,6 +141,7 @@ UIPostHeader.propTypes = {
 UIPostHeader.defaultProps = {
   avatarFileUrl: '',
   postAuthorName: '',
+  postAuthorId: null,
   postTargetName: '',
   timeAgo: null,
   isModerator: false,

--- a/src/social/components/post/Header/index.js
+++ b/src/social/components/post/Header/index.js
@@ -9,7 +9,7 @@ import { useNavigation } from '~/social/providers/NavigationProvider';
 import UIPostHeader from './UIPostHeader';
 import useCommunityOneMember from '~/social/hooks/useCommunityOneMember';
 
-const PostHeader = ({ postId, hidePostTarget, userType, loading }) => {
+const PostHeader = ({ postId, hidePostTarget, userType, loading, displayAccessCode }) => {
   const { onClickCommunity, onClickUser } = useNavigation();
   const { post, file, user } = usePost(postId);
 
@@ -33,6 +33,7 @@ const PostHeader = ({ postId, hidePostTarget, userType, loading }) => {
       userType={userType}
       avatarFileUrl={file.fileUrl}
       postAuthorName={user.displayName || <FormattedMessage id="anonymous" />}
+      postAuthorId={displayAccessCode ? user.userId : null}
       postTargetName={postTargetName}
       timeAgo={createdAt}
       isModerator={isCommunityModerator || isModerator(user.roles) || isAdmin(user.roles)}
@@ -50,11 +51,13 @@ PostHeader.propTypes = {
   postId: PropTypes.string,
   hidePostTarget: PropTypes.bool,
   loading: PropTypes.bool,
+  displayAccessCode: PropTypes.bool,
 };
 
 PostHeader.defaultProps = {
   hidePostTarget: false,
   loading: false,
+  displayAccessCode: false,
 };
 
 export { UIPostHeader };

--- a/src/social/components/post/Header/styles.js
+++ b/src/social/components/post/Header/styles.js
@@ -28,6 +28,14 @@ export const Name = styled.div`
   `}
 `;
 
+export const AccessCode = styled.div`
+  ${({ theme }) => theme.typography.body}
+
+  word-break: break-all;
+
+  color: #c3c4c3;
+`;
+
 export const ArrowSeparator = styled(ArrowRight).attrs({
   height: '8px',
   width: '8px',

--- a/src/social/providers/ConfigProvider.tsx
+++ b/src/social/providers/ConfigProvider.tsx
@@ -6,6 +6,14 @@ export type SocialConfiguration = {
   showCreatePublicCommunityOption?: boolean;
   showUserProfileMetadata?: boolean;
   showOldStyleComments?: boolean;
+  manateeUrl?: string;
+  dashboardUrl?: string;
+  isUserCurrentlyInStingDashCallback: (userAccessCode: string) => Promise<boolean>;
+  addCoachNoteCallback: (userAccessCode: string, note: string) => Promise<boolean>;
+  transferUserToStingCallback: (
+    userAccessCode: string,
+    optionalMessage?: string,
+  ) => Promise<boolean>;
 };
 
 const defaultConfig = {
@@ -13,6 +21,11 @@ const defaultConfig = {
   showCreatePublicCommunityOption: false,
   showUserProfileMetadata: false,
   showOldStyleComments: false,
+  manateeUrl: null,
+  dashboardUrl: null,
+  isUserCurrentlyInStingDashCallback: async (_uac: string) => false,
+  addCoachNoteCallback: async (_uac: string, _note: string) => false,
+  transferUserToStingCallback: async (_uac: string, _message?: string) => false,
 };
 
 const ConfigContext = createContext(defaultConfig);


### PR DESCRIPTION
## Motivation
Adding a user to the STING Dash involves quite a few steps (talk to core leader, make Jira ticket, transfer coach, make note, send message, etc). This makes it so that it takes us quite a long time before we're able to reach out to a user who is in need. These changes are meant to streamline things. There are also some general quality of life improvements that all coaches can benefit from here.

## Changes
- Add Manatee lookup to post/comment context menu
- Add Dash lookup to post/comment context menu
- Add STING modal to post/comment context menu (Allows for one step transfer, message, and note creation for STING cases)
- Added user access code next to user name in posts and comments
- NOTE: All of these changes are only visible/accessible to coaches. Users will not see any changes.

## Testing Done
- [ ] I have successfully ran the unit tests
- [ ] I have successfully ran the integration tests
- [x] I have successfully completed the manual testing of my changes and the surrounding code

## Relevant Links
[Design doc](https://docs.google.com/document/d/1Q8Bko5AS9kRFFfTYziJdl0fV4a1_ldS1JksIAPHxTvM/edit)

## Screenshots

### Before
<img width="223" alt="image" src="https://github.com/noom/community-web-uikit/assets/10712840/5ba02b62-2296-4fe2-be17-a45055ae5180">

### After
<img width="264" alt="image" src="https://github.com/noom/community-web-uikit/assets/10712840/47c9ffc9-22fc-4173-8ce6-ece74b742993">
<img width="464" alt="image" src="https://github.com/noom/community-web-uikit/assets/10712840/9f03ee78-2a33-4ff3-b7c3-38ec292c01bf">
<img width="457" alt="image" src="https://github.com/noom/community-web-uikit/assets/10712840/636115ba-bb5d-4d65-9657-7ab4044d1236">
