### PR TITLE
Remove option to message user from STING workflows

### DIFF
--- a/src/i18n/de.json
+++ b/src/i18n/de.json
@@ -439,8 +439,6 @@
   "sting.notesPlaceholder": "Why is this post STING-related? (Required)",
   "sting.notesAreRequired": "Notes are required.",
   "sting.coachNotes": "Coach Notes",
-  "sting.messagePlaceholder": "Enter a message to be sent to the user from the STING Guide after being transferred. (Optional)",
-  "sting.messageToSend": "Message to send to user",
   "sting.addNewNote": "Add New Note",
   "sting.transferUser": "Transfer User to STING Dash"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -439,8 +439,6 @@
   "sting.notesPlaceholder": "Why is this post STING-related? (Required)",
   "sting.notesAreRequired": "Notes are required.",
   "sting.coachNotes": "Coach Notes",
-  "sting.messagePlaceholder": "Enter a message to be sent to the user from the STING Guide after being transferred. (Optional)",
-  "sting.messageToSend": "Message to send to user",
   "sting.addNewNote": "Add New Note",
   "sting.transferUser": "Transfer User to STING Dash"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -439,8 +439,6 @@
   "sting.notesPlaceholder": "Why is this post STING-related? (Required)",
   "sting.notesAreRequired": "Notes are required.",
   "sting.coachNotes": "Coach Notes",
-  "sting.messagePlaceholder": "Enter a message to be sent to the user from the STING Guide after being transferred. (Optional)",
-  "sting.messageToSend": "Message to send to user",
   "sting.addNewNote": "Add New Note",
   "sting.transferUser": "Transfer User to STING Dash"
 }

--- a/src/social/components/Sting/StingModal.tsx
+++ b/src/social/components/Sting/StingModal.tsx
@@ -52,10 +52,10 @@ export const StingModal = ({ userAccessCode, pathToContent, isOpen, onClose }: S
     reset();
   }, [isOpen]);
 
-  const onSubmit = async (data: { messageToSend: string | undefined; coachNotes: string }) => {
+  const onSubmit = async (data: { coachNotes: string }) => {
     let canAttachNote = true;
     if (!userInStingDash) {
-      canAttachNote = await transferUserToStingCallback(userAccessCode, data.messageToSend);
+      canAttachNote = await transferUserToStingCallback(userAccessCode);
     }
     if (canAttachNote) {
       const realPath = pathToContent.replace(
@@ -107,17 +107,6 @@ export const StingModal = ({ userAccessCode, pathToContent, isOpen, onClose }: S
               />
               <ErrorMessage errors={errors} name="coachNotes" />
             </Box>
-            {!userInStingDash && (
-              <Box>
-                <FormLabel>
-                  <FormattedMessage id="sting.messageToSend" />
-                </FormLabel>
-                <Textarea
-                  placeholder={formatMessage({ id: 'sting.messagePlaceholder' })}
-                  {...register('messageToSend')}
-                />
-              </Box>
-            )}
 
             <ButtonGroup w="100%" justifyContent="center">
               <Button colorScheme="primary" type="submit">


### PR DESCRIPTION
## Motivation
There are potential QA concerns from having non-STING trained coaches sending messages from the STING dashboard, so we want to remove this option. I'm just removing it from the UI and not the callbacks in case we decide to add it back later.

## Changes
Remove UI to send message when transferring user to STING dash.
