### PR TITLE
[EVO-1079] Make create communities button configurable

### DIFF
--- a/src/social/components/SideSectionMyCommunity/index.js
+++ b/src/social/components/SideSectionMyCommunity/index.js
@@ -26,7 +26,7 @@ const SideSectionMyCommunity = ({
   currentUserId,
 }) => {
   const { connected } = useSDK();
-  const { socialCommunityCreationButtonVisible } = useConfig();
+  const { socialCommunityCreationButtonVisible , showCreateCommunity} = useConfig();
   const { onCommunityCreated } = useNavigation();
   const [isOpen, setIsOpen] = useState(false);
   const { user } = useUser(currentUserId, [currentUserId]);
@@ -39,10 +39,6 @@ const SideSectionMyCommunity = ({
     communityId && onCommunityCreated(communityId);
   };
 
-  const canCreateCommunity =
-    socialCommunityCreationButtonVisible &&
-    (userType !== 'user' || user?.metadata?.[BUSINESS_TYPE_METADATA] !== 'B2B');
-
   return (
     <Box bg="white" h="100%" pb={2} pt={1}>
       <ListHeading>
@@ -54,7 +50,7 @@ const SideSectionMyCommunity = ({
         <CommunityCount ml="auto" count={communityListProps?.communities?.length} />
       </ListHeading>
       <Box h="calc(100% - 50px)" minH={0} overflow="auto">
-        {canCreateCommunity && (
+        {showCreateCommunity && (
           <SideMenuActionItem
             icon={<Plus height={20} />}
             element="button"

--- a/src/social/providers/ConfigProvider.tsx
+++ b/src/social/providers/ConfigProvider.tsx
@@ -31,6 +31,7 @@ const defaultConfig = {
   showCreatePublicCommunityOption: false,
   showUserProfileMetadata: false,
   showOldStyleComments: false,
+  showCreateCommunity: false,
   manateeUrl: null,
   dashboardUrl: null,
   isUserCurrentlyInStingDashCallback: async (_uac: string) => false,


### PR DESCRIPTION
## Motivation
We want to hide the create community button by default and enable it only for Noom employees.

## Changes
Make the button configurable so the web app can control if it's visible or not using the user metadata.