### PR TITLE
[CT-2160] Fix HTML injection in user mentions

### DIFF
--- a/src/core/components/ChunkHighlighter/index.js
+++ b/src/core/components/ChunkHighlighter/index.js
@@ -61,7 +61,9 @@ export function formatMentionChunks(text = '', mentionees = [], tag = 'mention')
     const chunkText = text.substring(chunk.start, chunk.end);
 
     if (chunk.highlight) {
-      formattedText += `<${tag} highlightIndex="${highlightIndex}">${chunkText}</${tag}>`;
+      // Use a safe format that works with disableParsingRawHTML: true
+      // This creates a markdown-style link that will be processed by the mention override
+      formattedText += `[@${chunkText.replace('@', '')}](mention:${highlightIndex})`;
       highlightIndex += 1;
     } else {
       formattedText += chunkText;

--- a/src/core/components/ChunkHighlighter/index.js
+++ b/src/core/components/ChunkHighlighter/index.js
@@ -63,7 +63,9 @@ export function formatMentionChunks(text = '', mentionees = [], tag = 'mention')
     if (chunk.highlight) {
       // Use a safe format that works with disableParsingRawHTML: true
       // This creates a markdown-style link that will be processed by the mention override
-      formattedText += `[@${chunkText.replace('@', '')}](mention:${highlightIndex})`;
+      // Remove leading @ if present, then add it back to ensure consistent format
+      const cleanText = chunkText.startsWith('@') ? chunkText.slice(1) : chunkText;
+      formattedText += `[@${cleanText}](mention:${highlightIndex})`;
       highlightIndex += 1;
     } else {
       formattedText += chunkText;

--- a/src/social/components/Comment/CommentText.js
+++ b/src/social/components/Comment/CommentText.js
@@ -30,7 +30,15 @@ const CommentText = ({ text, className, mentionees, maxLines = COMMENT_MAX_LINES
         component: ({ href, children, ...props }) => {
           // Handle mention links with format: mention:index
           if (href && href.startsWith('mention:')) {
-            const highlightIndex = parseInt(href.replace('mention:', ''), 10);
+            const indexStr = href.replace('mention:', '');
+            const highlightIndex = parseInt(indexStr, 10);
+            
+            // Validate that we have a valid number
+            if (isNaN(highlightIndex) || highlightIndex < 0) {
+              console.warn(`Invalid mention index: ${indexStr}. Falling back to regular link.`);
+              return <a href={href} {...props}>{children}</a>;
+            }
+            
             return (
               <MentionHighlightTag 
                 highlightIndex={highlightIndex} 

--- a/src/social/components/Comment/CommentText.js
+++ b/src/social/components/Comment/CommentText.js
@@ -26,10 +26,23 @@ const CommentText = ({ text, className, mentionees, maxLines = COMMENT_MAX_LINES
     () => ({
       ...defaultBlockComponentMap,
       ...defaultMarkComponentMap,
-      mention: {
-        component: MentionHighlightTag,
-        props: {
-          mentionees,
+      a: {
+        component: ({ href, children, ...props }) => {
+          // Handle mention links with format: mention:index
+          if (href && href.startsWith('mention:')) {
+            const highlightIndex = parseInt(href.replace('mention:', ''), 10);
+            return (
+              <MentionHighlightTag 
+                highlightIndex={highlightIndex} 
+                mentionees={mentionees}
+                {...props}
+              >
+                {children}
+              </MentionHighlightTag>
+            );
+          }
+          // Regular links
+          return <a href={href} {...props}>{children}</a>;
         },
       },
     }),

--- a/src/social/components/post/TextContent/index.js
+++ b/src/social/components/post/TextContent/index.js
@@ -39,7 +39,15 @@ function TextContent({ text, postMaxLines, mentionees }) {
         component: ({ href, children, ...props }) => {
           // Handle mention links with format: mention:index
           if (href && href.startsWith('mention:')) {
-            const highlightIndex = parseInt(href.replace('mention:', ''), 10);
+            const indexStr = href.replace('mention:', '');
+            const highlightIndex = parseInt(indexStr, 10);
+            
+            // Validate that we have a valid number
+            if (isNaN(highlightIndex) || highlightIndex < 0) {
+              console.warn(`Invalid mention index: ${indexStr}. Falling back to regular link.`);
+              return <a href={href} {...props}>{children}</a>;
+            }
+            
             return (
               <MentionHighlightTag 
                 highlightIndex={highlightIndex} 

--- a/src/social/components/post/TextContent/index.js
+++ b/src/social/components/post/TextContent/index.js
@@ -35,10 +35,23 @@ function TextContent({ text, postMaxLines, mentionees }) {
     () => ({
       ...defaultBlockComponentMap,
       ...defaultMarkComponentMap,
-      mention: {
-        component: MentionHighlightTag,
-        props: {
-          mentionees,
+      a: {
+        component: ({ href, children, ...props }) => {
+          // Handle mention links with format: mention:index
+          if (href && href.startsWith('mention:')) {
+            const highlightIndex = parseInt(href.replace('mention:', ''), 10);
+            return (
+              <MentionHighlightTag 
+                highlightIndex={highlightIndex} 
+                mentionees={mentionees}
+                {...props}
+              >
+                {children}
+              </MentionHighlightTag>
+            );
+          }
+          // Regular links
+          return <a href={href} {...props}>{children}</a>;
         },
       },
     }),


### PR DESCRIPTION
## Motivation

User mentions in comments and posts were displaying as raw HTML tags (e.g., <mention highlightIndex="0">@user</mention>) instead of proper clickable mentions. This issue was caused by a recent security fix that enabled disableParsingRawHTML: true in the Markdown component to prevent HTML injection attacks, but inadvertently broke the custom <mention> tag rendering.

## Changes

This is the **"what"** of the change

- Updated formatMentionChunks function in ChunkHighlighter/index.js. Changed from generating raw HTML tags to markdown-style links: [@user](mention:index). This format is safe with disableParsingRawHTML: true while maintaining mention functionality
- Updated markdown render overrides in both CommentText.js and TextContent/index.js: Replaced custom mention component override with a (anchor) component override. Added logic to detect mention links with mention: prefix and render them as MentionHighlightTag components. Preserved regular link functionality for non-mention links
- Maintained security: The solution works within the existing disableParsingRawHTML: true setting, preventing HTML injection while restoring mention functionality

- Change 2

## Testing Done

- [x] Tested in Storybook with before/after comparison

## Relevant Links

- [CT-2160](https://noomhq.atlassian.net/browse/CT-2160)

## Screenshots

### Before
<img width="2360" height="1640" alt="IMG_7478" src="https://github.com/user-attachments/assets/35719484-bd70-4c08-a005-780186d01037" />

### After
<img width="255" height="139" alt="Screenshot 2025-09-23 at 9 15 44 AM" src="https://github.com/user-attachments/assets/6589f435-8969-41a0-a016-5800d31e6290" />


[CT-2160]: https://noomhq.atlassian.net/browse/CT-2160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ