### PR TITLE
[LHIOTC-41] Add entity.datadog.yaml and update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @noom/webbees
+*   @noom/fa-engagement

--- a/entity.datadog.yaml
+++ b/entity.datadog.yaml
@@ -1,0 +1,6 @@
+apiVersion: v3
+kind: repository
+metadata:
+  name: github.com/noom/community-web-uikit
+spec:
+  owner: fa_ege

--- a/entity.datadog.yaml
+++ b/entity.datadog.yaml
@@ -1,6 +1,0 @@
-apiVersion: v3
-kind: repository
-metadata:
-  name: github.com/noom/community-web-uikit
-spec:
-  owner: fa_ege


### PR DESCRIPTION
## Summary

- Add `entity.datadog.yaml` at repo root with `owner: fa_ege` (apiVersion v3, kind repository, metadata.name: `github.com/noom/community-web-uikit`) so ownership rolls up correctly to the `fa_ege` Snyk/Datadog organization
- Update `.github/CODEOWNERS` to reference `@noom/fa-engagement`, replacing the stale `@noom/webbees` entry

## Test plan

- [ ] Verify `entity.datadog.yaml` exists at repo root with correct `fa_ege` owner and metadata name `github.com/noom/community-web-uikit`
- [ ] Verify `.github/CODEOWNERS` references `@noom/fa-engagement`
- [ ] PR builds pass

Closes LHIOTC-41

🤖 Generated with [Claude Code](https://claude.com/claude-code)